### PR TITLE
Add Streamlit-based chatbot interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+.streamlit/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# sandbox-vanilla
+# Sandbox Vanilla Chatbot
+
+A minimal Streamlit interface that connects to the OpenAI API. It mimics a basic ChatGPT-style chat where conversation history is preserved in the session.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Provide your OpenAI API key via the `OPENAI_API_KEY` environment variable or Streamlit secrets.
+3. Start the app:
+   ```bash
+   streamlit run app.py
+   ```
+
+## Notes
+
+- Conversation is stored only in your current browser session.
+- This project is intentionally minimal to serve as a starting point for further customization.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,43 @@
+import os
+from typing import List, Dict
+
+import streamlit as st
+from openai import OpenAI
+
+
+st.title("ChatGPT-like Chatbot")
+
+# Initialize chat history
+if "messages" not in st.session_state:
+    st.session_state.messages: List[Dict[str, str]] = []
+
+
+def get_client() -> OpenAI:
+    """Create an OpenAI client using an API key from env or Streamlit secrets."""
+    api_key = st.secrets.get("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        st.error("OPENAI_API_KEY is not set.\n\nSet it via environment variable or Streamlit secrets.")
+        st.stop()
+    return OpenAI(api_key=api_key)
+
+
+# Display chat messages from history on app rerun
+for msg in st.session_state.messages:
+    with st.chat_message(msg["role"]):
+        st.markdown(msg["content"])
+
+# Accept user input
+if prompt := st.chat_input("Ask the bot..."):
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    client = get_client()
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": m["role"], "content": m["content"]} for m in st.session_state.messages],
+    )
+    reply = response.choices[0].message.content
+    st.session_state.messages.append({"role": "assistant", "content": reply})
+    with st.chat_message("assistant"):
+        st.markdown(reply)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+openai


### PR DESCRIPTION
## Summary
- create Streamlit app `app.py` that chats with OpenAI's API and preserves session history
- document setup and usage in README
- add dependencies list and `.streamlit` to gitignore

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5ce3f47708332b944672c74ef1bfe